### PR TITLE
Manual: use inkscape instead of convert

### DIFF
--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -21,11 +21,7 @@ add_custom_target(ctp-gitid COMMAND ${CMAKE_COMMAND}
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES gitid.tex)
 add_custom_command(OUTPUT gitid.tex DEPENDS ctp-gitid)
 
-include(theory/CMakeLists.txt)        # manual_SOURCES
-include(fig/CMakeLists.txt)           # manual_FIGURES
-include(input/CMakeLists.txt)         # manual_XML
-
-foreach(prog votca_property)
+foreach(prog votca_property inkscape dvipdf)
   string(TOUPPER "${prog}" PROG)
   if(TARGET ${prog})
     set(${PROG} $<TARGET_FILE:${prog}>)
@@ -36,6 +32,11 @@ foreach(prog votca_property)
     message(FATAL_ERROR "Could not find ${prog}")
   endif()
 endforeach()
+
+include(theory/CMakeLists.txt)        # manual_SOURCES
+include(fig/CMakeLists.txt)           # manual_FIGURES
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fig)
+include(input/CMakeLists.txt)         # manual_XML
 
 set(CTP_PROGS_FULL)
 foreach(prog ${CTP_PROGS})
@@ -84,14 +85,16 @@ ADD_LATEX_DOCUMENT( ctp-manual.tex
             ${manual_SOURCES} 
             ${manual_PROGRAMS}
             ${manual_XML}
-            ${manual_FIGURES}
-    DEPENDS reference/calculators.tex reference/programs.tex  gitid.tex
+    DEPENDS reference/calculators.tex reference/programs.tex  gitid.tex ${manual_FIGURES}
     TARGET_NAME ctp-manual
-    IMAGE_DIRS fig
     BIBFILES manual.bib
     USE_INDEX
-    FORCE_PDF
+    FORCE_DVI
 )
 
-#add_custom_target(ctp-manual_pdf ALL DEPENDS ctp-manual.pdf)
+add_custom_command(OUTPUT ctp-manual.pdf
+  COMMAND ${DVIPDF} ctp-manual.dvi ctp-manual.pdf
+  DEPENDS ctp-manual_dvi
+)
+add_custom_target(ctp-manual_pdf ALL DEPENDS ctp-manual.pdf)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ctp-manual.pdf DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/manual/fig/CMakeLists.txt
+++ b/manual/fig/CMakeLists.txt
@@ -1,11 +1,11 @@
-list(APPEND manual_FIGURES
-    "fig/logo.svg"
-    "fig/dcv2t.svg"
-    "fig/coupling.svg"
-    "fig/fragment_segment.svg"
-    "fig/monomer_parabolas.svg"
-    "fig/workflow.svg"
-)
+foreach(PIC fig/logo fig/dcv2t fig/coupling fig/fragment_segment fig/monomer_parabolas fig/workflow)
+  add_custom_command(OUTPUT ${PIC}.eps
+    COMMAND ${INKSCAPE} -f ${CMAKE_CURRENT_SOURCE_DIR}/${PIC}.svg
+      -E ${CMAKE_CURRENT_BINARY_DIR}/${PIC}.eps
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fig
+    DEPENDS ${PIC}.svg)
+  list(APPEND manual_FIGURES "${PIC}.eps")
+endforeach()
 
 #appendix/derivation_jortner.tex:%    \includegraphics[width=1.0\textwidth]{fig/jortner_rate/marcus_parabolas_new}
 #appendix/derivation_jortner.tex:%   \includegraphics[width=\linewidth]{fig/jortner_rate/compare_rates}


### PR DESCRIPTION
Due to https://www.kb.cert.org/vuls/id/332928, Ubuntu doesn't
allow conversion of svg to eps with 'convert' anymore, so let's
use inkscape instead.