### PR TITLE
Pcc64le fix lexical cast

### DIFF
--- a/src/libctp/apolarsite.cc
+++ b/src/libctp/apolarsite.cc
@@ -806,14 +806,14 @@ vector<APolarSite*> APS_FROM_MPS(string filename, int state, QMThread *thread) {
                 double x, y, z;
 
                 if (units == "bohr") {
-                    x = BOHR2NM * boost::lexical_cast<double>(split[1]);
-                    y = BOHR2NM * boost::lexical_cast<double>(split[2]);
-                    z = BOHR2NM * boost::lexical_cast<double>(split[3]);
+                    x = BOHR2NM * stod(split[1]);
+                    y = BOHR2NM * stod(split[2]);
+                    z = BOHR2NM * stod(split[3]);
                 }
                 else if (units == "angstrom") {
-                    x = ANGSTROM2NM * boost::lexical_cast<double>(split[1]);
-                    y = ANGSTROM2NM * boost::lexical_cast<double>(split[2]);
-                    z = ANGSTROM2NM * boost::lexical_cast<double>(split[3]);
+                    x = ANGSTROM2NM * stod(split[1]);
+                    y = ANGSTROM2NM * stod(split[2]);
+                    z = ANGSTROM2NM * stod(split[3]);
                 }
                 else {
                     throw std::runtime_error( "Unit " + units + " in file "
@@ -834,18 +834,18 @@ vector<APolarSite*> APS_FROM_MPS(string filename, int state, QMThread *thread) {
                 double      pyy, pyz;
                 double           pzz;
                 if (split.size() == 7) {
-                    pxx = 1e-3 * boost::lexical_cast<double>(split[1]);
-                    pxy = 1e-3 * boost::lexical_cast<double>(split[2]);
-                    pxz = 1e-3 * boost::lexical_cast<double>(split[3]);
-                    pyy = 1e-3 * boost::lexical_cast<double>(split[4]);
-                    pyz = 1e-3 * boost::lexical_cast<double>(split[5]);
-                    pzz = 1e-3 * boost::lexical_cast<double>(split[6]);
+                    pxx = 1e-3 * stod(split[1]);
+                    pxy = 1e-3 * stod(split[2]);
+                    pxz = 1e-3 * stod(split[3]);
+                    pyy = 1e-3 * stod(split[4]);
+                    pyz = 1e-3 * stod(split[5]);
+                    pzz = 1e-3 * stod(split[6]);
                     P1 = matrix(vec(pxx,pxy,pxz),
                                 vec(pxy,pyy,pyz),
                                 vec(pxz,pyz,pzz));
                 }
                 else if (split.size() == 2) {
-                    pxx = 1e-3 * boost::lexical_cast<double>(split[1]);
+                    pxx = 1e-3 * stod(split[1]);
                     pxy = 0.0;
                     pxz = 0.0;
                     pyy = pxx;
@@ -866,10 +866,10 @@ vector<APolarSite*> APS_FROM_MPS(string filename, int state, QMThread *thread) {
             else {
                 int lineRank = int( sqrt(Qs.size()) + 0.5 );
                 if (lineRank == 0) {
-                    Q0_total += boost::lexical_cast<double>(split[0]);
+                    Q0_total += stod(split[0]);
                 }
                 for (unsigned i = 0; i < split.size(); i++) {
-                    double qXYZ = boost::lexical_cast<double>(split[i]);
+                    double qXYZ = stod(split[i]);
                     // Convert e*(a_0)^k to e*(nm)^k where k = rank
                     double BOHR2NM = 0.0529189379;
                     qXYZ *= pow(BOHR2NM, lineRank); // OVERRIDE

--- a/src/libctp/calculators/eimport.h
+++ b/src/libctp/calculators/eimport.h
@@ -111,8 +111,8 @@ bool EImport::EvaluateFrame(Topology *top) {
                     assert(state_N == 0);
                     assert(state_C*state_C == 1);
 
-                    double e_N = boost::lexical_cast<double>(split[3]);
-                    double e_C = boost::lexical_cast<double>(split[5]);
+                    double e_N = stod(split[3]);
+                    double e_C = stod(split[5]);
 
                     seg->setEMpoles(state_N, e_N);
                     seg->setEMpoles(state_C, e_C);
@@ -128,9 +128,9 @@ bool EImport::EvaluateFrame(Topology *top) {
                     assert(state_A == -1);
                     assert(state_C == +1);
 
-                    double e_N = boost::lexical_cast<double>(split[3]);
-                    double e_A = boost::lexical_cast<double>(split[5]);
-                    double e_C = boost::lexical_cast<double>(split[7]);
+                    double e_N = stod(split[3]);
+                    double e_A = stod(split[5]);
+                    double e_C = stod(split[7]);
 
                     seg->setEMpoles(state_N, e_N);
                     seg->setEMpoles(state_A, e_A);

--- a/src/libctp/calculators/emultipole.h
+++ b/src/libctp/calculators/emultipole.h
@@ -989,14 +989,14 @@ vector<PolarSite*> EMultipole::ParseGdmaFile(string filename, int state) {
                 double x, y, z;
 
                 if (units == "bohr") {
-                    x = BOHR2NM * boost::lexical_cast<double>(split[1]);
-                    y = BOHR2NM * boost::lexical_cast<double>(split[2]);
-                    z = BOHR2NM * boost::lexical_cast<double>(split[3]);
+                    x = BOHR2NM * stod(split[1]);
+                    y = BOHR2NM * stod(split[2]);
+                    z = BOHR2NM * stod(split[3]);
                 }
                 else if (units == "angstrom") {
-                    x = ANGSTROM2NM * boost::lexical_cast<double>(split[1]);
-                    y = ANGSTROM2NM * boost::lexical_cast<double>(split[2]);
-                    z = ANGSTROM2NM * boost::lexical_cast<double>(split[3]);
+                    x = ANGSTROM2NM * stod(split[1]);
+                    y = ANGSTROM2NM * stod(split[2]);
+                    z = ANGSTROM2NM * stod(split[3]);
                 }
                 else {
                     throw std::runtime_error( "Unit " + units + " in file "
@@ -1020,7 +1020,7 @@ vector<PolarSite*> EMultipole::ParseGdmaFile(string filename, int state) {
                 if (split.size() == 7) {
                     warn_anisotropy = true;
                 }
-                P1 = 1e-3 * boost::lexical_cast<double>(split[1]);
+                P1 = 1e-3 * stod(split[1]);
                 thisPole->setPs(P1, state);
                 useDefaultPs = false;
             }
@@ -1031,12 +1031,12 @@ vector<PolarSite*> EMultipole::ParseGdmaFile(string filename, int state) {
                 int lineRank = int( sqrt(thisPole->getQs(state).size()) + 0.5 );
 
                 if (lineRank == 0) {
-                    Q0_total += boost::lexical_cast<double>(split[0]);
+                    Q0_total += stod(split[0]);
                 }
 
                 for (unsigned int i = 0; i < split.size(); i++) {
 
-                    double qXYZ = boost::lexical_cast<double>(split[i]);
+                    double qXYZ = stod(split[i]);
 
                     // Convert e*(a_0)^k to e*(nm)^k where k = rank
                     double BOHR2NM = 0.0529189379;
@@ -1141,9 +1141,9 @@ vector<vec> EMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 3) {
 
                 assert( split.size() == 4 );
-                double ox = boost::lexical_cast<double>( split[1] );
-                double oy = boost::lexical_cast<double>( split[2] );
-                double oz = boost::lexical_cast<double>( split[3] );
+                double ox = stod( split[1] );
+                double oy = stod( split[2] );
+                double oz = stod( split[3] );
 
                 cube[0] = vec(ox, oy, oz);
             }
@@ -1170,12 +1170,12 @@ vector<vec> EMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 4) {
 
                 assert( split.size() == 4 );
-                Nx = boost::lexical_cast<double>( split[0] );
+                Nx = stod( split[0] );
                 ext2nm = (Nx > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nx = (Nx >= 0) ? Nx : -Nx;
-                double xx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double xy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double xz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double xx = ext2nm * stod( split[1] );
+                double xy = ext2nm * stod( split[2] );
+                double xz = ext2nm * stod( split[3] );
 
                 cube[2] = vec(xx, xy, xz);                
             }
@@ -1183,12 +1183,12 @@ vector<vec> EMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 5) {
 
                 assert( split.size() == 4 );
-                Ny = boost::lexical_cast<double>( split[0] );
+                Ny = stod( split[0] );
                 ext2nm = (Ny > 0) ? BOHR2NM : ANGSTROM2NM;
                 Ny = (Ny >= 0) ? Ny : -Ny;
-                double yx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double yy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double yz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double yx = ext2nm * stod( split[1] );
+                double yy = ext2nm * stod( split[2] );
+                double yz = ext2nm * stod( split[3] );
 
                 cube[3] = vec(yx, yy, yz);
             }
@@ -1196,12 +1196,12 @@ vector<vec> EMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 6) {
 
                 assert( split.size() == 4 );
-                Nz = boost::lexical_cast<double>( split[0] );
+                Nz = stod( split[0] );
                 ext2nm = (Nz > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nz = (Nz >= 0) ? Nz : -Nz;
-                double zx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double zy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double zz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double zx = ext2nm * stod( split[1] );
+                double zy = ext2nm * stod( split[2] );
+                double zz = ext2nm * stod( split[3] );
 
                 cube[4] = vec(zx, zy, zz);
                 cube[1] = vec(Nx, Ny, Nz);
@@ -1650,9 +1650,9 @@ void EMultipole::CalculateESF(Topology *top) {
 
             else {
 
-                double x = CONVERT2NM * boost::lexical_cast<double>(split[0]);
-                double y = CONVERT2NM * boost::lexical_cast<double>(split[1]);
-                double z = CONVERT2NM * boost::lexical_cast<double>(split[2]);
+                double x = CONVERT2NM * stod(split[0]);
+                double y = CONVERT2NM * stod(split[1]);
+                double z = CONVERT2NM * stod(split[2]);
 
                 gridPoints.push_back(vec(x,y,z));
             }

--- a/src/libctp/calculators/emultipole_stdal.h
+++ b/src/libctp/calculators/emultipole_stdal.h
@@ -672,14 +672,14 @@ vector<PolarSite*> EMultipole_StdAl::ParseGdmaFile(string filename, int state) {
                 double x, y, z;
 
                 if (units == "bohr") {
-                    x = BOHR2NM * boost::lexical_cast<double>(split[1]);
-                    y = BOHR2NM * boost::lexical_cast<double>(split[2]);
-                    z = BOHR2NM * boost::lexical_cast<double>(split[3]);
+                    x = BOHR2NM * stod(split[1]);
+                    y = BOHR2NM * stod(split[2]);
+                    z = BOHR2NM * stod(split[3]);
                 }
                 else if (units == "angstrom") {
-                    x = ANGSTROM2NM * boost::lexical_cast<double>(split[1]);
-                    y = ANGSTROM2NM * boost::lexical_cast<double>(split[2]);
-                    z = ANGSTROM2NM * boost::lexical_cast<double>(split[3]);
+                    x = ANGSTROM2NM * stod(split[1]);
+                    y = ANGSTROM2NM * stod(split[2]);
+                    z = ANGSTROM2NM * stod(split[3]);
                 }
                 else {
                     throw std::runtime_error( "Unit " + units + " in file "
@@ -700,7 +700,7 @@ vector<PolarSite*> EMultipole_StdAl::ParseGdmaFile(string filename, int state) {
 
             // 'P', dipole polarizability
             else if ( split[0] == "P" && split.size() == 2 ) {
-                P1 = 1e-3 * boost::lexical_cast<double>(split[1]);
+                P1 = 1e-3 * stod(split[1]);
                 thisPole->setPs(P1, state);
                 useDefaultPs = false;
             }
@@ -711,12 +711,12 @@ vector<PolarSite*> EMultipole_StdAl::ParseGdmaFile(string filename, int state) {
                 int lineRank = int( sqrt(thisPole->getQs(state).size()) + 0.5 );
 
                 if (lineRank == 0) {
-                    Q0_total += boost::lexical_cast<double>(split[0]);
+                    Q0_total += stod(split[0]);
                 }
 
                 for (unsigned int i = 0; i < split.size(); i++) {
 
-                    double qXYZ = boost::lexical_cast<double>(split[i]);
+                    double qXYZ = stod(split[i]);
 
                     // Convert e*(a_0)^k to e*(nm)^k where k = rank
                     double BOHR2NM = 0.0529189379;
@@ -816,9 +816,9 @@ vector<vec> EMultipole_StdAl::ParseCubeFileHeader(string filename) {
             if (lineCount == 3) {
 
                 assert( split.size() == 4 );
-                double ox = boost::lexical_cast<double>( split[1] );
-                double oy = boost::lexical_cast<double>( split[2] );
-                double oz = boost::lexical_cast<double>( split[3] );
+                double ox = stod( split[1] );
+                double oy = stod( split[2] );
+                double oz = stod( split[3] );
 
                 cube[0] = vec(ox, oy, oz);
             }
@@ -845,12 +845,12 @@ vector<vec> EMultipole_StdAl::ParseCubeFileHeader(string filename) {
             if (lineCount == 4) {
 
                 assert( split.size() == 4 );
-                Nx = boost::lexical_cast<double>( split[0] );
+                Nx = stod( split[0] );
                 ext2nm = (Nx > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nx = (Nx >= 0) ? Nx : -Nx;
-                double xx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double xy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double xz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double xx = ext2nm * stod( split[1] );
+                double xy = ext2nm * stod( split[2] );
+                double xz = ext2nm * stod( split[3] );
 
                 cube[2] = vec(xx, xy, xz);                
             }
@@ -858,12 +858,12 @@ vector<vec> EMultipole_StdAl::ParseCubeFileHeader(string filename) {
             if (lineCount == 5) {
 
                 assert( split.size() == 4 );
-                Ny = boost::lexical_cast<double>( split[0] );
+                Ny = stod( split[0] );
                 ext2nm = (Ny > 0) ? BOHR2NM : ANGSTROM2NM;
                 Ny = (Ny >= 0) ? Ny : -Ny;
-                double yx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double yy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double yz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double yx = ext2nm * stod( split[1] );
+                double yy = ext2nm * stod( split[2] );
+                double yz = ext2nm * stod( split[3] );
 
                 cube[3] = vec(yx, yy, yz);
             }
@@ -871,12 +871,12 @@ vector<vec> EMultipole_StdAl::ParseCubeFileHeader(string filename) {
             if (lineCount == 6) {
 
                 assert( split.size() == 4 );
-                Nz = boost::lexical_cast<double>( split[0] );
+                Nz = stod( split[0] );
                 ext2nm = (Nz > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nz = (Nz >= 0) ? Nz : -Nz;
-                double zx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double zy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double zz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double zx = ext2nm * stod( split[1] );
+                double zy = ext2nm * stod( split[2] );
+                double zz = ext2nm * stod( split[3] );
 
                 cube[4] = vec(zx, zy, zz);
                 cube[1] = vec(Nx, Ny, Nz);

--- a/src/libctp/calculators/eoutersphere.cc
+++ b/src/libctp/calculators/eoutersphere.cc
@@ -378,14 +378,14 @@ vector<PolarSite*> EOutersphere::ParseGdmaFile(string filename, int state) {
                 double x, y, z;
 
                 if (units == "bohr") {
-                    x = BOHR2NM * boost::lexical_cast<double>(split[1]);
-                    y = BOHR2NM * boost::lexical_cast<double>(split[2]);
-                    z = BOHR2NM * boost::lexical_cast<double>(split[3]);
+                    x = BOHR2NM * stod(split[1]);
+                    y = BOHR2NM * stod(split[2]);
+                    z = BOHR2NM * stod(split[3]);
                 }
                 else if (units == "angstrom") {
-                    x = ANGSTROM2NM * boost::lexical_cast<double>(split[1]);
-                    y = ANGSTROM2NM * boost::lexical_cast<double>(split[2]);
-                    z = ANGSTROM2NM * boost::lexical_cast<double>(split[3]);
+                    x = ANGSTROM2NM * stod(split[1]);
+                    y = ANGSTROM2NM * stod(split[2]);
+                    z = ANGSTROM2NM * stod(split[3]);
                 }
                 else {
                     throw std::runtime_error( "Unit " + units + " in file "
@@ -409,7 +409,7 @@ vector<PolarSite*> EOutersphere::ParseGdmaFile(string filename, int state) {
                 if (split.size() == 7) {
                     warn_anisotropy = true;
                 }
-                P1 = 1e-3 * boost::lexical_cast<double>(split[1]);
+                P1 = 1e-3 * stod(split[1]);
                 thisPole->setPs(P1, state);
                 useDefaultPs = false;
             }
@@ -420,12 +420,12 @@ vector<PolarSite*> EOutersphere::ParseGdmaFile(string filename, int state) {
                 int lineRank = int( sqrt(thisPole->getQs(state).size()) + 0.5 );
 
                 if (lineRank == 0) {
-                    Q0_total += boost::lexical_cast<double>(split[0]);
+                    Q0_total += stod(split[0]);
                 }
 
                 for (unsigned int i = 0; i < split.size(); i++) {
 
-                    double qXYZ = boost::lexical_cast<double>(split[i]);
+                    double qXYZ = stod(split[i]);
 
                     // Convert e*(a_0)^k to e*(nm)^k where k = rank
                     double BOHR2NM = 0.0529189379;

--- a/src/libctp/calculators/iimport.h
+++ b/src/libctp/calculators/iimport.h
@@ -192,7 +192,7 @@ void IImport::List2PairsTI(Topology *top, string &ti_file) {
             }            
 
             int e_h_1 = (split[2] == "e") ? -1 : +1;
-            double j2_1 = boost::lexical_cast<double>(split[3]);
+            double j2_1 = stod(split[3]);
 
             if (split.size() == 6) {
 
@@ -201,7 +201,7 @@ void IImport::List2PairsTI(Topology *top, string &ti_file) {
                     cout << endl << "... ... Invalid line: " << line << flush;
                     continue;
                 }
-                double j2_2 = boost::lexical_cast<double>(split[5]);
+                double j2_2 = stod(split[5]);
 
                 qmp->setJeff2(j2_2, e_h_2);
                 qmp->setIsPathCarrier(true, e_h_2);
@@ -295,9 +295,9 @@ void IImport::StochasticTI(Topology *top, string &filename, int state) {
                       split[0] == "!"   ||
                       split[0].substr(0,1) == "!" ) { continue; }
              
-                double distance          = boost::lexical_cast<double>(split[0]);
-                double mean              = boost::lexical_cast<double>(split[1]);
-                double sigma             = boost::lexical_cast<double>(split[2]);
+                double distance          = stod(split[0]);
+                double mean              = stod(split[1]);
+                double sigma             = stod(split[2]);
                 cout << "        " << distance << " nm:   " << mean << " +/- " << sigma << endl;
                 distances.push_back(distance);
                 means.push_back(mean);
@@ -384,14 +384,14 @@ void IImport::XML2PairTI(QMPair *qmpair, string &xmlDirFile) {
                 assert(TRANSPORT == "electron" || TRANSPORT == "hole");
                 STATE = (TRANSPORT == "electron") ? -1 : +1;
                 if (_TI_tag == "J" || _TI_tag == "T_00") {
-                    double J = boost::lexical_cast<double>(split[1]);
+                    double J = stod(split[1]);
                     qmpair->setJeff2(J*J, STATE);
                     qmpair->setIsPathCarrier(1, STATE);
                     printf("\n... ... ... J2(State = %+1d) = %4.7e",
                             STATE, qmpair->getJeff2(STATE));
                 }
                 else if (_TI_tag == "J_sq_degen" || _TI_tag == "J_sq_boltz") {
-                    double J2 = boost::lexical_cast<double>(split[1]);
+                    double J2 = stod(split[1]);
                     qmpair->setJeff2(J2, STATE);
                     qmpair->setIsPathCarrier(1, STATE);
                     printf("\n... ... ... J2(State = %+1d) = %4.7e",

--- a/src/libctp/calculators/qmultipole.h
+++ b/src/libctp/calculators/qmultipole.h
@@ -945,9 +945,9 @@ vector<vec> QMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 3) {
 
                 assert( split.size() == 4 );
-                double ox = boost::lexical_cast<double>( split[1] );
-                double oy = boost::lexical_cast<double>( split[2] );
-                double oz = boost::lexical_cast<double>( split[3] );
+                double ox = stod( split[1] );
+                double oy = stod( split[2] );
+                double oz = stod( split[3] );
 
                 cube[0] = vec(ox, oy, oz);
             }
@@ -974,12 +974,12 @@ vector<vec> QMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 4) {
 
                 assert( split.size() == 4 );
-                Nx = boost::lexical_cast<double>( split[0] );
+                Nx = stod( split[0] );
                 ext2nm = (Nx > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nx = (Nx >= 0) ? Nx : -Nx;
-                double xx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double xy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double xz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double xx = ext2nm * stod( split[1] );
+                double xy = ext2nm * stod( split[2] );
+                double xz = ext2nm * stod( split[3] );
 
                 cube[2] = vec(xx, xy, xz);
             }
@@ -987,12 +987,12 @@ vector<vec> QMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 5) {
 
                 assert( split.size() == 4 );
-                Ny = boost::lexical_cast<double>( split[0] );
+                Ny = stod( split[0] );
                 ext2nm = (Ny > 0) ? BOHR2NM : ANGSTROM2NM;
                 Ny = (Ny >= 0) ? Ny : -Ny;
-                double yx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double yy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double yz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double yx = ext2nm * stod( split[1] );
+                double yy = ext2nm * stod( split[2] );
+                double yz = ext2nm * stod( split[3] );
 
                 cube[3] = vec(yx, yy, yz);
             }
@@ -1000,12 +1000,12 @@ vector<vec> QMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 6) {
 
                 assert( split.size() == 4 );
-                Nz = boost::lexical_cast<double>( split[0] );
+                Nz = stod( split[0] );
                 ext2nm = (Nz > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nz = (Nz >= 0) ? Nz : -Nz;
-                double zx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double zy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double zz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double zx = ext2nm * stod( split[1] );
+                double zy = ext2nm * stod( split[2] );
+                double zz = ext2nm * stod( split[3] );
 
                 cube[4] = vec(zx, zy, zz);
                 cube[1] = vec(Nx, Ny, Nz);
@@ -1325,9 +1325,9 @@ void QMultipole::CalculateESF(Topology *top) {
 
             else {
 
-                double x = CONVERT2NM * boost::lexical_cast<double>(split[0]);
-                double y = CONVERT2NM * boost::lexical_cast<double>(split[1]);
-                double z = CONVERT2NM * boost::lexical_cast<double>(split[2]);
+                double x = CONVERT2NM * stod(split[0]);
+                double y = CONVERT2NM * stod(split[1]);
+                double z = CONVERT2NM * stod(split[2]);
 
                 gridPoints.push_back(vec(x,y,z));
             }

--- a/src/libctp/calculators/xmultipole.h
+++ b/src/libctp/calculators/xmultipole.h
@@ -893,14 +893,14 @@ vector<PolarSite*> XMultipole::ParseGdmaFile(string filename, int state) {
                 double x, y, z;
 
                 if (units == "bohr") {
-                    x = BOHR2NM * boost::lexical_cast<double>(split[1]);
-                    y = BOHR2NM * boost::lexical_cast<double>(split[2]);
-                    z = BOHR2NM * boost::lexical_cast<double>(split[3]);
+                    x = BOHR2NM * stod(split[1]);
+                    y = BOHR2NM * stod(split[2]);
+                    z = BOHR2NM * stod(split[3]);
                 }
                 else if (units == "angstrom") {
-                    x = ANGSTROM2NM * boost::lexical_cast<double>(split[1]);
-                    y = ANGSTROM2NM * boost::lexical_cast<double>(split[2]);
-                    z = ANGSTROM2NM * boost::lexical_cast<double>(split[3]);
+                    x = ANGSTROM2NM * stod(split[1]);
+                    y = ANGSTROM2NM * stod(split[2]);
+                    z = ANGSTROM2NM * stod(split[3]);
                 }
                 else {
                     throw std::runtime_error( "Unit " + units + " in file "
@@ -921,7 +921,7 @@ vector<PolarSite*> XMultipole::ParseGdmaFile(string filename, int state) {
 
             // 'P', dipole polarizability
             else if ( split[0] == "P" && split.size() == 2 ) {
-                P1 = 1e-3 * boost::lexical_cast<double>(split[1]);
+                P1 = 1e-3 * stod(split[1]);
                 thisPole->setPs(P1, state);
                 useDefaultPs = false;
             }
@@ -932,12 +932,12 @@ vector<PolarSite*> XMultipole::ParseGdmaFile(string filename, int state) {
                 int lineRank = int( sqrt(thisPole->getQs(state).size()) + 0.5 );
 
                 if (lineRank == 0) {
-                    Q0_total += boost::lexical_cast<double>(split[0]);
+                    Q0_total += stod(split[0]);
                 }
 
                 for (int i = 0; i < split.size(); i++) {
 
-                    double qXYZ = boost::lexical_cast<double>(split[i]);
+                    double qXYZ = stod(split[i]);
 
                     // Convert e*(a_0)^k to e*(nm)^k where k = rank
                     double BOHR2NM = 0.0529189379;

--- a/src/libctp/calculators/xmultipole2.h
+++ b/src/libctp/calculators/xmultipole2.h
@@ -1963,14 +1963,14 @@ vector<PolarSite*> XMP::Parse_GDMA(string filename, int state) {
                 double x, y, z;
 
                 if (units == "bohr") {
-                    x = BOHR2NM * boost::lexical_cast<double>(split[1]);
-                    y = BOHR2NM * boost::lexical_cast<double>(split[2]);
-                    z = BOHR2NM * boost::lexical_cast<double>(split[3]);
+                    x = BOHR2NM * stod(split[1]);
+                    y = BOHR2NM * stod(split[2]);
+                    z = BOHR2NM * stod(split[3]);
                 }
                 else if (units == "angstrom") {
-                    x = ANGSTROM2NM * boost::lexical_cast<double>(split[1]);
-                    y = ANGSTROM2NM * boost::lexical_cast<double>(split[2]);
-                    z = ANGSTROM2NM * boost::lexical_cast<double>(split[3]);
+                    x = ANGSTROM2NM * stod(split[1]);
+                    y = ANGSTROM2NM * stod(split[2]);
+                    z = ANGSTROM2NM * stod(split[3]);
                 }
                 else {
                     throw std::runtime_error( "Unit " + units + " in file "
@@ -1991,7 +1991,7 @@ vector<PolarSite*> XMP::Parse_GDMA(string filename, int state) {
 
             // 'P', dipole polarizability
             else if ( split[0] == "P" && split.size() == 2 ) {
-                P1 = 1e-3 * boost::lexical_cast<double>(split[1]);
+                P1 = 1e-3 * stod(split[1]);
                 thisPole->setPs(P1, state);
                 useDefaultPs = false;
             }
@@ -2002,12 +2002,12 @@ vector<PolarSite*> XMP::Parse_GDMA(string filename, int state) {
                 int lineRank = int( sqrt(thisPole->getQs(state).size()) + 0.5 );
 
                 if (lineRank == 0) {
-                    Q0_total += boost::lexical_cast<double>(split[0]);
+                    Q0_total += stod(split[0]);
                 }
 
                 for (unsigned int i = 0; i < split.size(); i++) {
 
-                    double qXYZ = boost::lexical_cast<double>(split[i]);
+                    double qXYZ = stod(split[i]);
 
                     // Convert e*(a_0)^k to e*(nm)^k where k = rank
                     double BOHR2NM = 0.0529189379;

--- a/src/libctp/calculators/zmultipole.h
+++ b/src/libctp/calculators/zmultipole.h
@@ -938,9 +938,9 @@ vector<vec> ZMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 3) {
 
                 assert( split.size() == 4 );
-                double ox = boost::lexical_cast<double>( split[1] );
-                double oy = boost::lexical_cast<double>( split[2] );
-                double oz = boost::lexical_cast<double>( split[3] );
+                double ox = stod( split[1] );
+                double oy = stod( split[2] );
+                double oz = stod( split[3] );
 
                 cube[0] = vec(ox, oy, oz);
             }
@@ -967,12 +967,12 @@ vector<vec> ZMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 4) {
 
                 assert( split.size() == 4 );
-                Nx = boost::lexical_cast<double>( split[0] );
+                Nx = stod( split[0] );
                 ext2nm = (Nx > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nx = (Nx >= 0) ? Nx : -Nx;
-                double xx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double xy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double xz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double xx = ext2nm * stod( split[1] );
+                double xy = ext2nm * stod( split[2] );
+                double xz = ext2nm * stod( split[3] );
 
                 cube[2] = vec(xx, xy, xz);
             }
@@ -980,12 +980,12 @@ vector<vec> ZMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 5) {
 
                 assert( split.size() == 4 );
-                Ny = boost::lexical_cast<double>( split[0] );
+                Ny = stod( split[0] );
                 ext2nm = (Ny > 0) ? BOHR2NM : ANGSTROM2NM;
                 Ny = (Ny >= 0) ? Ny : -Ny;
-                double yx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double yy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double yz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double yx = ext2nm * stod( split[1] );
+                double yy = ext2nm * stod( split[2] );
+                double yz = ext2nm * stod( split[3] );
 
                 cube[3] = vec(yx, yy, yz);
             }
@@ -993,12 +993,12 @@ vector<vec> ZMultipole::ParseCubeFileHeader(string filename) {
             if (lineCount == 6) {
 
                 assert( split.size() == 4 );
-                Nz = boost::lexical_cast<double>( split[0] );
+                Nz = stod( split[0] );
                 ext2nm = (Nz > 0) ? BOHR2NM : ANGSTROM2NM;
                 Nz = (Nz >= 0) ? Nz : -Nz;
-                double zx = ext2nm * boost::lexical_cast<double>( split[1] );
-                double zy = ext2nm * boost::lexical_cast<double>( split[2] );
-                double zz = ext2nm * boost::lexical_cast<double>( split[3] );
+                double zx = ext2nm * stod( split[1] );
+                double zy = ext2nm * stod( split[2] );
+                double zz = ext2nm * stod( split[3] );
 
                 cube[4] = vec(zx, zy, zz);
                 cube[1] = vec(Nx, Ny, Nz);
@@ -1322,9 +1322,9 @@ void ZMultipole::CalculateESF(Topology *top) {
 
             else {
 
-                double x = CONVERT2NM * boost::lexical_cast<double>(split[0]);
-                double y = CONVERT2NM * boost::lexical_cast<double>(split[1]);
-                double z = CONVERT2NM * boost::lexical_cast<double>(split[2]);
+                double x = CONVERT2NM * stod(split[0]);
+                double y = CONVERT2NM * stod(split[1]);
+                double z = CONVERT2NM * stod(split[2]);
 
                 gridPoints.push_back(vec(x,y,z));
             }

--- a/src/libctp/qmpackages/gaussian.cc
+++ b/src/libctp/qmpackages/gaussian.cc
@@ -412,7 +412,7 @@ bool Gaussian::ParseOrbitalsFile( Orbitals* _orbitals )
             
             _level = boost::lexical_cast<int>(results.front());
             boost::replace_first(results.back(), "D", "e");
-            _energies[ _level ] = boost::lexical_cast<double>( results.back() );            
+            _energies[ _level ] = stod( results.back() );            
             _levels++;
 
         } else {
@@ -422,7 +422,7 @@ bool Gaussian::ParseOrbitalsFile( Orbitals* _orbitals )
                 _coefficient.assign( _line, 0, 15 );
                 boost::trim( _coefficient );
                 boost::replace_first( _coefficient, "D", "e" );
-                double coefficient = boost::lexical_cast<double>( _coefficient );
+                double coefficient = stod( _coefficient );
                 _coefficients[ _level ].push_back( coefficient );
                 _line.erase(0, 15);
             }
@@ -579,7 +579,7 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
         /*std::string::size_type HFX_pos = _line.find("ScaHFX=");
          if (HFX_pos != std::string::npos) {
              boost::algorithm::split(results, _line, boost::is_any_of("\t "), boost::algorithm::token_compress_on);
-             double _ScaHFX = boost::lexical_cast<double>(results.back()) ;
+             double _ScaHFX = stod(results.back()) ;
              _orbitals->setScaHFX( _ScaHFX );
              CTP_LOG(logDEBUG,*_pLog) << "DFT with " << _ScaHFX << " of HF exchange!" << flush ;
          } */
@@ -728,11 +728,11 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
                         string  _coefficient = *iter;
                        
                         boost::replace_first( _coefficient, "D", "e" );
-                        //cout << boost::lexical_cast<double>( _coefficient ) << endl;
+                        //cout << stod( _coefficient ) << endl;
                         
                         int _j_index = *_j_iter;                                
-                        //_overlap( _i_index-1 , _j_index-1 ) = boost::lexical_cast<double>( _coefficient );
-                        overlap( _i_index-1 , _j_index-1 ) = boost::lexical_cast<double>( _coefficient );
+                        //_overlap( _i_index-1 , _j_index-1 ) = stod( _coefficient );
+                        overlap( _i_index-1 , _j_index-1 ) = stod( _coefficient );
                         _j_iter++;
                         
                     }
@@ -836,9 +836,9 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
                 
                 vector<string>::iterator it_atom;
                 it_atom = atom.end();
-                double _z =  boost::lexical_cast<double>( *(--it_atom) );
-                double _y =  boost::lexical_cast<double>( *(--it_atom) );
-                double _x =  boost::lexical_cast<double>( *(--it_atom) );
+                double _z =  stod( *(--it_atom) );
+                double _y =  stod( *(--it_atom) );
+                double _x =  stod( *(--it_atom) );
                 
                 if ( _has_atoms == false ) {
                         _orbitals->AddAtom( _atom_type, _x, _y, _z );
@@ -859,7 +859,7 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
             vector<string> energy;
             boost::algorithm::split(block, *coord_block, boost::is_any_of("\\"), boost::algorithm::token_compress_on);
             //boost::algorithm::split(energy, block[1], boost::is_any_of("="), boost::algorithm::token_compress_on);
-            //_orbitals->setQMEnergy( _conv_Hrt_eV * boost::lexical_cast<double> ( energy[1] ) );
+            //_orbitals->setQMEnergy( _conv_Hrt_eV * stod( energy[1] ) );
             map<string,string> properties;
             vector<string>::iterator block_it;
             for (block_it = block.begin(); block_it != block.end(); ++block_it) {
@@ -872,7 +872,7 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
             //_orbitals->_has_atoms = true;
             //_orbitals->_has_qm_energy = true;
             if (properties.count("HF") > 0) {
-                double energy_hartree = boost::lexical_cast<double>(properties["HF"]);
+                double energy_hartree = stod(properties["HF"]);
                 //_orbitals->setQMEnergy(_has_qm_energy = true;
                 _orbitals-> setQMEnergy( _conv_Hrt_eV * energy_hartree );
                 CTP_LOG(logDEBUG, *_pLog) << "QM energy " << _orbitals->_qm_energy <<  flush;
@@ -884,7 +884,7 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
             
 //            boost::algorithm::split(energy, block[1], boost::is_any_of("="), boost::algorithm::token_compress_on);
 //            cout << endl << energy[1] << endl;
-//            _orbitals->_qm_energy = _conv_Hrt_eV * boost::lexical_cast<double> ( energy[1] );
+//            _orbitals->_qm_energy = _conv_Hrt_eV * stod( energy[1] );
 //            
 //            CTP_LOG(logDEBUG, *_pLog) << "QM energy " << _orbitals->_qm_energy <<  flush;
 //            _has_qm_energy = true;
@@ -904,7 +904,7 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
             boost::algorithm::split(energy, block[1], boost::is_any_of("\t "), boost::algorithm::token_compress_on);
             
             // _orbitals->_has_self_energy = true;
-            _orbitals->setSelfEnergy( _conv_Hrt_eV * boost::lexical_cast<double> ( energy[1] ) );
+            _orbitals->setSelfEnergy( _conv_Hrt_eV * stod( energy[1] ) );
             
             CTP_LOG(logDEBUG, *_pLog) << "Self energy = " << _orbitals->getSelfEnergy() <<  flush;
 
@@ -962,8 +962,8 @@ bool Gaussian::ParseLogFile( Orbitals* _orbitals ) {
                 
            int _i_index = boost::lexical_cast<int>(  _row[0]  ); 
            int _j_index = boost::lexical_cast<int>(  _row[1]  );
-           //cout << "Vxc element [" << _i_index << ":" << _j_index << "] " << boost::lexical_cast<double>( _row[2] ) << endl;
-           _vxc( _i_index-1 , _j_index-1 ) = boost::lexical_cast<double>( _row[2] );
+           //cout << "Vxc element [" << _i_index << ":" << _j_index << "] " << stod( _row[2] ) << endl;
+           _vxc( _i_index-1 , _j_index-1 ) = stod( _row[2] );
         }
         
         CTP_LOG(logDEBUG,*_pLog) << "Done parsing" << flush;

--- a/src/libctp/qmpackages/nwchem.cc
+++ b/src/libctp/qmpackages/nwchem.cc
@@ -671,7 +671,7 @@ bool NWChem::ParseLogFile( Orbitals* _orbitals ) {
             boost::algorithm::split(results, _line, boost::is_any_of("="), boost::algorithm::token_compress_on);
             string _energy = results.back();
             boost::trim( _energy );
-            _orbitals->setQMEnergy ( _conv_Hrt_eV * boost::lexical_cast<double>(_energy) );
+            _orbitals->setQMEnergy ( _conv_Hrt_eV * stod(_energy) );
             CTP_LOG(logDEBUG, *_pLog) << "QM energy " << _orbitals->getQMEnergy() <<  flush;
             _has_qm_energy = true;
             // _orbitals->_has_qm_energy = true;
@@ -727,7 +727,7 @@ bool NWChem::ParseLogFile( Orbitals* _orbitals ) {
                         string  _coefficient = *iter;
                        
                         int _j_index = *_j_iter;                                
-                        _orbitals->_overlap( _i_index-1 , _j_index-1 ) = boost::lexical_cast<double>( _coefficient );
+                        _orbitals->_overlap( _i_index-1 , _j_index-1 ) = stod( _coefficient );
                         _j_iter++;
                         
                     }
@@ -829,9 +829,9 @@ bool NWChem::ParseLogFile( Orbitals* _orbitals ) {
                 //int atom_number = boost::lexical_cast< int >( _row.at(0) );
                 
                 string _atom_type = _row.at(1);
-                double _x =  boost::lexical_cast<double>( _row.at(3) );
-                double _y =  boost::lexical_cast<double>( _row.at(4) );
-                double _z =  boost::lexical_cast<double>( _row.at(5) );
+                double _x =  stod( _row.at(3) );
+                double _y =  stod( _row.at(4) );
+                double _z =  stod( _row.at(5) );
                 //if ( tools::globals::verbose ) cout << "... ... " << atom_id << " " << atom_type << " " << atom_charge << endl;
                 getline(_input_file, _line);
                 boost::trim( _line );
@@ -868,7 +868,7 @@ bool NWChem::ParseLogFile( Orbitals* _orbitals ) {
             boost::algorithm::split(energy, block[1], boost::is_any_of("\t "), boost::algorithm::token_compress_on);
             
             // _orbitals->_has_self_energy = true;
-            _orbitals->setSelfEnergy( _conv_Hrt_eV * boost::lexical_cast<double> ( energy[1] ) );
+            _orbitals->setSelfEnergy( _conv_Hrt_eV * stod( energy[1] ) );
             
             CTP_LOG(logDEBUG, *_pLog) << "Self energy " << _orbitals->getSelfEnergy() <<  flush;
 

--- a/src/libctp/qmpackages/turbomole.cc
+++ b/src/libctp/qmpackages/turbomole.cc
@@ -28,6 +28,7 @@
 #include <boost/filesystem.hpp>
 
 #include <stdio.h>
+#include <string>
 #include <iomanip>
 #include <sys/stat.h>
 
@@ -368,7 +369,7 @@ bool Turbomole::ParseOrbitalsFile( Orbitals* _orbitals )
             
             _level = boost::lexical_cast<int>(results.front());
             boost::replace_first(results[3], "D", "e");
-            _energies[ _level ] = stod( results[3] );            
+            _energies[ _level ] = std::stod( results[3] );            
             _levels++;
 
         } else if ( dollar_pos == std::string::npos ) {
@@ -378,7 +379,7 @@ bool Turbomole::ParseOrbitalsFile( Orbitals* _orbitals )
                 _coefficient.assign( _line, 0, 20 );
                 boost::trim( _coefficient );
                 boost::replace_first( _coefficient, "D", "e" );
-                double coefficient = stod( _coefficient );
+                double coefficient = std::stod( _coefficient );
                 _coefficients[ _level ].push_back( coefficient );
                 _line.erase(0, 20);
             }
@@ -611,10 +612,10 @@ bool Turbomole::ParseLogFile( Orbitals* _orbitals ) {
                     //cout << "  " << *it << endl;
                             
                     boost::trim( *it );
-                    double _coefficient = stod( *it );
+                    double _coefficient = std::stod( *it );
                     //cout << _i_index << ":" << _j_index << ":" << _coefficient << endl;
                     
-                    _orbitals->_overlap( _i_index , _j_index ) = stod( _coefficient );
+                    _orbitals->_overlap( _i_index , _j_index ) = ( _coefficient );
                     
                     _j_index++;
                     if ( _j_index > _i_index ) {

--- a/src/libctp/qmpackages/turbomole.cc
+++ b/src/libctp/qmpackages/turbomole.cc
@@ -368,7 +368,7 @@ bool Turbomole::ParseOrbitalsFile( Orbitals* _orbitals )
             
             _level = boost::lexical_cast<int>(results.front());
             boost::replace_first(results[3], "D", "e");
-            _energies[ _level ] = boost::lexical_cast<double>( results[3] );            
+            _energies[ _level ] = stod( results[3] );            
             _levels++;
 
         } else if ( dollar_pos == std::string::npos ) {
@@ -378,7 +378,7 @@ bool Turbomole::ParseOrbitalsFile( Orbitals* _orbitals )
                 _coefficient.assign( _line, 0, 20 );
                 boost::trim( _coefficient );
                 boost::replace_first( _coefficient, "D", "e" );
-                double coefficient = boost::lexical_cast<double>( _coefficient );
+                double coefficient = stod( _coefficient );
                 _coefficients[ _level ].push_back( coefficient );
                 _line.erase(0, 20);
             }
@@ -611,10 +611,10 @@ bool Turbomole::ParseLogFile( Orbitals* _orbitals ) {
                     //cout << "  " << *it << endl;
                             
                     boost::trim( *it );
-                    double _coefficient = boost::lexical_cast<double>( *it );
+                    double _coefficient = stod( *it );
                     //cout << _i_index << ":" << _j_index << ":" << _coefficient << endl;
                     
-                    _orbitals->_overlap( _i_index , _j_index ) = boost::lexical_cast<double>( _coefficient );
+                    _orbitals->_overlap( _i_index , _j_index ) = stod( _coefficient );
                     
                     _j_index++;
                     if ( _j_index > _i_index ) {

--- a/src/libctp/tools/pdb2map.h
+++ b/src/libctp/tools/pdb2map.h
@@ -366,9 +366,9 @@ void PDB2Map::readPDB(){
             
             try
             {
-            _xd = boost::lexical_cast<double>(_x);
-            _yd = boost::lexical_cast<double>(_y);
-            _zd = boost::lexical_cast<double>(_z);
+            _xd = stod(_x);
+            _yd = stod(_y);
+            _zd = stod(_z);
             _resNumInt = boost::lexical_cast<int>(_resNum);
             }
             catch(boost::bad_lexical_cast &)
@@ -519,9 +519,9 @@ void PDB2Map::readGRO(){
                 _resNumInt = boost::lexical_cast<int>(_resNum);
 		//_atNumInt  = boost::lexical_cast<int>(_atNum);
 
-                _xd = boost::lexical_cast<double>(_x);
-                _yd = boost::lexical_cast<double>(_y);
-                _zd = boost::lexical_cast<double>(_z);
+                _xd = stod(_x);
+                _yd = stod(_y);
+                _zd = stod(_z);
             }
             catch (boost::bad_lexical_cast &)
             {
@@ -635,7 +635,7 @@ void PDB2Map::readXYZ(){
         // first line, number of atoms in XYZ
         std::getline(_file, _line,'\n');
         ba::trim(_line);
-        //int numXYZatoms = boost::lexical_cast<double>(_line);
+        //int numXYZatoms = stod(_line);
     }
     catch(boost::bad_lexical_cast &)
     {
@@ -665,9 +665,9 @@ void PDB2Map::readXYZ(){
         // try transform xyz coords to double
         double _xd(0),_yd(0),_zd(0);
         try{
-            _xd = boost::lexical_cast<double>(_x);
-            _yd = boost::lexical_cast<double>(_y);
-            _zd = boost::lexical_cast<double>(_z);
+            _xd = stod(_x);
+            _yd = stod(_y);
+            _zd = stod(_z);
         }
         catch(boost::bad_lexical_cast &)
         {

--- a/src/libctp/tools/pdb2top.h
+++ b/src/libctp/tools/pdb2top.h
@@ -308,9 +308,9 @@ void PDB2Top::readPDB(){
             
             try
             {
-            _xd = boost::lexical_cast<double>(_x);
-            _yd = boost::lexical_cast<double>(_y);
-            _zd = boost::lexical_cast<double>(_z);
+            _xd = stod(_x);
+            _yd = stod(_y);
+            _zd = stod(_z);
             _resNumInt = boost::lexical_cast<int>(_resNum);
             }
             catch(boost::bad_lexical_cast &)
@@ -458,9 +458,9 @@ void PDB2Top::readGRO(){
                 _resNumInt = boost::lexical_cast<int>(_resNum);
                 //_atNumInt  = boost::lexical_cast<int>(_atNum);
 
-                _xd = boost::lexical_cast<double>(_x);
-                _yd = boost::lexical_cast<double>(_y);
-                _zd = boost::lexical_cast<double>(_z);
+                _xd = stod(_x);
+                _yd = stod(_y);
+                _zd = stod(_z);
             }
             catch (boost::bad_lexical_cast &)
             {

--- a/src/libmoo/fock.cc
+++ b/src/libmoo/fock.cc
@@ -87,12 +87,12 @@ void fock::SetParameters(){
     vector<string>::iterator it= Mutok.begin();
     for (; it != Mutok.end();++it)
     {
-        Mu.push_back(boost::lexical_cast<double>(*it));
+        Mu.push_back(stod(*it));
     }
      it= Betatok.begin();
     for (; it != Betatok.end();++it)
     {
-        Beta.push_back(boost::lexical_cast<double>(*it));
+        Beta.push_back(stod(*it));
     }
 }
 

--- a/src/tools/Md2QmEngine.cc
+++ b/src/tools/Md2QmEngine.cc
@@ -231,7 +231,7 @@ void Md2QmEngine::Initialize(const string &xmlfile) {
                }
                
                // Mapping weight
-               double weight = boost::lexical_cast<double>(*it_atom_weight);
+               double weight = stod(*it_atom_weight);
                if (!hasQMPart && weight != 0) {
                    cout << "ERROR: "
                         << "Atom " << md_atom_name << " in residue "
@@ -574,9 +574,9 @@ void Md2QmEngine::getIntCoords(string &file,
             // Interesting information written here: e.g. 'C 0.000 0.000 0.000'
             atomCount++;
             string element = split[0];
-            double x = boost::lexical_cast<double>( split[1] ) / 10.; //°A to NM
-            double y = boost::lexical_cast<double>( split[2] ) / 10.;
-            double z = boost::lexical_cast<double>( split[3] ) / 10.;
+            double x = stod( split[1] ) / 10.; //°A to NM
+            double y = stod( split[2] ) / 10.;
+            double z = stod( split[3] ) / 10.;
             vec qmPos = vec(x,y,z);
 
             pair<string, vec> qmTypePos(element, qmPos);


### PR DESCRIPTION
Fixes error related to fedora build on pcc64le architecture, error arises from boost::lexical_cast<double> failure to preserve negative sign. 