### PR TITLE
.gitlab-ci.yml: allow rawhide builds to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,6 +127,7 @@ Debug GCC Rawhide:
     CMAKE_BUILD_TYPE: "Debug"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Debug Clang Rawhide:
   variables:
@@ -135,6 +136,7 @@ Debug Clang Rawhide:
     CMAKE_BUILD_TYPE: "Debug"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release GCC Rawhide:
   variables:
@@ -143,6 +145,7 @@ Release GCC Rawhide:
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release Clang Rawhide:
   variables:
@@ -151,6 +154,7 @@ Release Clang Rawhide:
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release GCC Module:
   variables:


### PR DESCRIPTION
Part of https://github.com/votca/votca/pull/159

Workaround for https://github.com/openucx/ucx/issues/3558